### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*    @vector-im/compound
-*    @vector-im/compound-web-reviewers
+* @element-hq/compound-reviewers

--- a/package.json
+++ b/package.json
@@ -11,16 +11,8 @@
     "check": "yarn exec biome -- check",
     "types": "yarn exec tsc -- --noEmit"
   },
-  "keywords": [
-    "compound",
-    "design tokens",
-    "style dictionary",
-    "css"
-  ],
-  "files": [
-    "./assets/web/**/*",
-    "./icons/**/*"
-  ],
+  "keywords": ["compound", "design tokens", "style dictionary", "css"],
+  "files": ["./assets/web/**/*", "./icons/**/*"],
   "main": "assets/web/js/index.js",
   "type": "module",
   "exports": {


### PR DESCRIPTION
I've gotten IT to create [a new team](https://github.com/orgs/element-hq/teams/compound-reviewers) for code reviewers for the core Compound repositories, which I think makes more sense than requesting reviews from @element-hq/compound (which includes designers) and @element-hq/compound-web-reviewers (which includes Web engineers that don't necessarily want to touch design token stuff). The group consists of myself, @jmartinesp, and @pixlwave, but we can change it more easily now if anyone wants to go on/off that list.