### PR TITLE
Avoid messing up formatting in the release workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -34,6 +34,7 @@ jobs:
       - name: 👊 Bump version
         run: |
           yarn version --no-git-tag-version --${{ github.event.inputs.version-bump }}
+          yarn format --write
           git config --global user.name 'ElementRobot'
           git config --global user.email 'releases@riot.im'
           git commit -am "${{ github.event.inputs.version-bump }} version bump"

--- a/package.json
+++ b/package.json
@@ -11,16 +11,8 @@
     "check": "yarn exec biome -- check",
     "types": "yarn exec tsc -- --noEmit"
   },
-  "keywords": [
-    "compound",
-    "design tokens",
-    "style dictionary",
-    "css"
-  ],
-  "files": [
-    "./assets/web/**/*",
-    "./icons/**/*"
-  ],
+  "keywords": ["compound", "design tokens", "style dictionary", "css"],
+  "files": ["./assets/web/**/*", "./icons/**/*"],
   "main": "assets/web/js/index.js",
   "type": "module",
   "exports": {


### PR DESCRIPTION
`yarn version` has a tendency to reformat package.json differently from Biome.