### PR TITLE
Fix Colour Studio applet

### DIFF
--- a/scripts/colour-studio/src/index.js
+++ b/scripts/colour-studio/src/index.js
@@ -656,7 +656,7 @@ function generateContrastGridUrl(themesJson, themeName, colorName) {
 
   for (const color of themeJson) {
     if (color.name === colorName) {
-      for (const swatch of color.value) {
+      for (const swatch of color.values) {
         contrastGridColors += `${swatch.value}, ${swatch.name}\n`;
       }
     }


### PR DESCRIPTION
This was a typo introduced in 104f3b098cf0a86fa9b1b3ccc098b11a73490550.