### PR TITLE
Include src/colors in package.json `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "files": [
     "./assets/web/**/*",
-    "./icons/**/*"
+    "./icons/**/*",
+    "./src/colors/*"
   ],
   "main": "assets/web/js/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "files": [
     "./assets/web/**/*",
     "./icons/**/*",
-    "./src/colors/*"
+    "./src/colors/**/*"
   ],
   "main": "assets/web/js/index.js",
   "type": "module",
@@ -89,10 +89,18 @@
     "zod": "^4.0.0"
   },
   "peerDependencies": {
+    "@adobe/leonardo-contrast-colors": "^1.0.0",
     "@types/react": "*",
+    "chroma-js": "^3.0.0",
     "react": "^17 || ^18 || ^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@adobe/leonardo-contrast-colors": {
+      "optional": true
+    },
+    "chroma-js": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },

--- a/patches/apca-w3.patch
+++ b/patches/apca-w3.patch
@@ -1,0 +1,31 @@
+diff --git a/src/apca-w3.js b/src/apca-w3.js
+index 07b4451b88818163d8e3db0a7058261757353069..75013b517672ef5799a36937dbf0f9f995f7a817 100644
+--- a/src/apca-w3.js
++++ b/src/apca-w3.js
+@@ -135,7 +135,6 @@
+ /*    ////  LOCAL TESTING SWITCH for using test.html
+     import{colorParsley}from'../node_modules/colorparsley/src/colorparsley.js';
+ /*/   //// TOGGLE
+-    import { colorParsley } from 'colorparsley';
+ // */ //// END LOCAL TESTING SWITCH
+ 
+ 
+@@ -426,18 +425,6 @@ export function reverseAPCA (contrast = 0,knownY = 1.0,
+ 
+ 
+ 
+-//////////  ƒ  calcAPCA()  /////////////////////////////////////////////
+-export function calcAPCA (textColor, bgColor, places = -1, round = true) {
+-
+-        // Note that this function requires colorParsley !!
+-	let bgClr = colorParsley(bgColor);
+-	let txClr = colorParsley(textColor);
+-	let hasAlpha = (txClr[3] == '' || txClr[3] == 1) ? false : true ;
+-
+-	if (hasAlpha) { txClr = alphaBlend( txClr, bgClr, round); };
+-
+-	return APCAcontrast( sRGBtoY(txClr), sRGBtoY(bgClr), places)
+-} // End calcAPCA()
+ 
+ 
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  colorparsley: '-'
+
+patchedDependencies:
+  apca-w3: 7ba6d4d5e1cefdaa323b8533d5dd3f37bcc501d733d8e121eb29734d42835d1c
+
 importers:
 
   .:
@@ -68,7 +74,7 @@ importers:
         version: 24.13.3
       apca-w3:
         specifier: ^0.1.9
-        version: 0.1.9
+        version: 0.1.9(patch_hash=7ba6d4d5e1cefdaa323b8533d5dd3f37bcc501d733d8e121eb29734d42835d1c)
       chroma-js:
         specifier: ^3.0.0
         version: 3.2.0
@@ -1048,9 +1054,6 @@ packages:
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
-  colorparsley@0.1.8:
-    resolution: {integrity: sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw==}
-
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -1900,7 +1903,7 @@ snapshots:
 
   '@adobe/leonardo-contrast-colors@1.1.0':
     dependencies:
-      apca-w3: 0.1.9
+      apca-w3: 0.1.9(patch_hash=7ba6d4d5e1cefdaa323b8533d5dd3f37bcc501d733d8e121eb29734d42835d1c)
       chroma-js: 3.2.0
       ciebase: 0.1.1
       ciecam02: 0.4.6
@@ -2619,9 +2622,7 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  apca-w3@0.1.9:
-    dependencies:
-      colorparsley: 0.1.8
+  apca-w3@0.1.9(patch_hash=7ba6d4d5e1cefdaa323b8533d5dd3f37bcc501d733d8e121eb29734d42835d1c): {}
 
   argparse@2.0.1: {}
 
@@ -2724,8 +2725,6 @@ snapshots:
   color-name@1.1.4: {}
 
   colorjs.io@0.5.2: {}
-
-  colorparsley@0.1.8: {}
 
   commander@11.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,12 @@ onlyBuiltDependencies:
 
 allowBuilds:
   esbuild: true
+
+overrides:
+  # AGPL code which adobe leonardo doesn't actually call upon
+  colorparsley: "-"
+
+patchedDependencies:
+  # Patch out unconditional import of colorparsley
+  apca-w3: patches/apca-w3.patch
+

--- a/src/colors/theme.js
+++ b/src/colors/theme.js
@@ -1,6 +1,6 @@
 import { BackgroundColor, Color, Theme } from "@adobe/leonardo-contrast-colors";
 import chroma from "chroma-js";
-import { getAlphaColor, hslaToHex } from "./alphredo";
+import { getAlphaColor, hslaToHex } from "./alphredo.js";
 
 // Color spaces for color interpolation
 // CAM02, CAM02p, LCH, LAB, HSL, HSLuv, HSV, RGB, OKLAB, OKLCH


### PR DESCRIPTION
Added src/colors to the files array in package.json

Also fixes import path to make node happy in a caller.

Ideally it'd be a distinct subpackage within a monorepo but that is a much heavier lift.